### PR TITLE
synced scrolling fix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -49,6 +49,25 @@ To solve a possible delay reading a 10MB index.tsx all at once...
 *   **Configure Loader**: Set `loader.config({ paths: { vs: window.__MONACO_VS_URI__ } })` so Monaco lazy-loads instead of bundling entirely.
 *   **Fix Workers**: Fix cross-origin worker issues by returning a Blob in `getWorkerUrl` that uses `importScripts('${window.__MONACO_VS_URI__}/base/worker/workerMain.js')` so bundler plugins are not required.
 
+### Profiler Insights - First Launch
+
+The trace confirms several bottlenecks that back up the lazy-load idea:
+*   **Startup Latency**: `EvaluateScript` (~863ms) and `v8.compile` (~221ms) consume **>1s** during webview initialization for the **11MB** bundle. This effectively blocks the main thread during the critical first paint.
+*   **Persistent Animations**: Long-running `Animation` slices (up to **3.8s**) account for nearly **70%** of the 5.5s trace session. This suggests that the side-panel transitions (`AnimatedColumn`) or SVG overlays (`DiffCurtain`) may be triggering redundant layout work or failing to terminate.
+*   **Execution Hotspots**:
+    *   `performWorkUntilDeadline` (React Scheduler) is the dominant function call, indicating React is struggling with a high volume of work or double-rendering (check `React.StrictMode` impact).
+    *   `onmessage` and `l.onmessage` show overhead in the webview-to-extension message bus coordination.
+
+### Profiler Insights - Resizing & Scrolling
+
+The traces `Trace-20260307T154206_resizing.json` and `Trace-20260307T154834_scrolling.json` reveal significant localized bottlenecks:
+*   **Synchronous Layout Thrashing**: During scrolling, `DiffCurtain.tsx` calls `getTopForLineNumber()` multiple times per diff chunk. In a file with many changes, this triggers hundreds of synchronous layout hits to Monaco's engine per frame, exceeding the 16ms budget.
+*   **Async Task Loop**: 43,019 `v8::Debugger::AsyncTaskRun` slices indicate a scroll-synchronization feedback loop. The `scrollLock` release in `requestAnimationFrame` (in `useSynchronizedScrolling.ts`) creates a window where events are queued before the lock resets.
+*   **React Render Storm**: `setRenderTrigger` is called on every scroll pixel, forcing a full reconciliation of the `Meld` app, all 5 editors, and all SVG curtains 60+ times per second.
+*   **Highlight Calculation Sink**: `getHighlights(index)` is called during every `App` render. For every `replace` chunk, it performs string slicing, joining, and calls `diffChars()` (character-level diffing) on the main thread. This is a massive CPU sink that should be memoized or computed once per content change.
+*   **Resize Overhead**: Resizing the window triggers ~1,800 layout passes. Monaco resizes every pixel, and `ResizeObserver` callbacks in the curtains trigger forced layouts by measuring `getBoundingClientRect()`.
+*   **CSS Animation Bloat**: Scrollbar fade animations are running for ~780ms, likely because layout thrashing prevents them from settling or fading out smoothly.
+
 ## Open Blank 3-way merge
 
 For people that want a 3-way merge with copy/pasted content. We'd need to make
@@ -58,7 +77,7 @@ save individual panels. Low !/$.
 
 ## Assorted Polish
 
-- **Scroll Perf**: `React.memo(CodePane)` to prevent full re-renders on scroll frames.
+- **Scroll Perf**: Throttle `setRenderTrigger` or move curtain drawing out of React; use `React.memo` for `CodePane`; cache line positions to avoid synchronous `getTopForLineNumber` calls during scroll.
 - **Maintainability**: Replace magic indices (0-4) with an `enum`/`const` mapping or just use arrays.
 - **Fix Returns**: Handle failures properly, e.g. from `getGitState`, without silently passing empty strings.
 - **UX**: Rethink `Ctrl+K` to avoid interfering with global VS Code chord prefixes.

--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
 		"vscode:prepublish": "npm run build",
 		"build:webview": "esbuild ./src/webview/ui/index.tsx --bundle --outfile=./out/webview/index.js --format=iife --platform=browser --loader:.ttf=file",
 		"build:extension": "esbuild ./src/extension.ts --bundle --outfile=./out/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
-		"build": "npm run format && npm run lint && npm run knip && npm run build:webview && npm run build:extension && tsc --noEmit",
+		"build": "tsc --noEmit && npm run format && npm run lint && npm run knip && npm run build:webview && npm run build:extension",
 		"watch:webview": "esbuild ./src/webview/ui/index.tsx --bundle --outfile=./out/webview/index.js --format=iife --platform=browser --loader:.ttf=file --watch",
 		"watch:extension": "esbuild ./src/extension.ts --bundle --outfile=./out/extension.js --external:vscode --format=cjs --platform=node --sourcemap --watch",
 		"watch": "npm run watch:webview & npm run watch:extension & tsc --noEmit --watch",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "meld-auto-merge",
 	"displayName": "Meld Merge",
 	"description": "3-way git merge conflict editor, a GNOME Meld Merge port",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"icon": "images/icon.png",
 	"publisher": "pknowles",
 	"author": "Pyarelal Knowles",

--- a/src/webview/ui/App.tsx
+++ b/src/webview/ui/App.tsx
@@ -1000,7 +1000,7 @@ const App: React.FC = () => {
 										leftEditor={editorRefs.current[leftEditorIdx]}
 										rightEditor={editorRefs.current[rightEditorIdx]}
 										renderTrigger={renderTrigger}
-										reversed={index === 1} // diffs[1] is Merged(a) <-> Local(b)
+										reversed={index === 1 || index === 3} // diffs[1] (A=2, B=1) and diff[3] (A=4, B=3) are reversed
 										fadeOutLeft={fadeOutLeft}
 										fadeOutRight={fadeOutRight}
 										onApplyChunk={

--- a/src/webview/ui/panesMapping.test.ts
+++ b/src/webview/ui/panesMapping.test.ts
@@ -1,0 +1,123 @@
+import { mapLineAcrossPanes } from "./scrollMapping";
+import type { DiffChunk } from "./types";
+
+describe("5-Pane Scroll Mapping Regression Test", () => {
+	// The setup that caused the bug:
+	// Pane 1 (Local): 10 lines
+	// Pane 2 (Merged): 100 lines
+	// diffs[1] (Local-Merged): A=Merged(100 lines), B=Local(10 lines)
+	// Note: Our scrollMapping utility expects diffs[i] to connect Pane i and Pane i+1.
+	// In our case:
+	// diffs[1] connects Pane 1 (Local) and Pane 2 (Merged).
+	// By original convention (A=left, B=right), it SHOULD have been A=Local, B=Merged.
+	// BUT the data payload provides it as A=Merged, B=Local.
+	// So diffIsReversed[1] must be true.
+
+	const paneCounts = [100, 10, 100, 10, 100]; // Base, Local, Merged, Remote, BaseR
+
+	// A replacement chunk that covers the whole file.
+	// In Merged (Pane 2, Side A), it's lines 0-100.
+	// In Local (Pane 1, Side B), it's lines 0-10.
+	const diffs: (DiffChunk[] | null)[] = [
+		null, // diffs[0] (Base - Local)
+		[{ tag: "replace", start_a: 0, end_a: 100, start_b: 0, end_b: 10 }], // diffs[1] (Local - Merged)
+		null, // diffs[2] (Merged - Remote)
+		null, // diffs[3] (Remote - BaseR)
+	];
+
+	it("should map from Local to Merged without throwing even if Merged is longer", () => {
+		const sourceIdx = 1; // Local
+		const targetIdx = 2; // Merged
+		const sourceLine = 5; // Middle of Local
+
+		expect(() => {
+			mapLineAcrossPanes(
+				sourceLine,
+				sourceIdx,
+				targetIdx,
+				diffs,
+				paneCounts,
+				true, // smooth
+				[false, true, false, false],
+			);
+		}).not.toThrow();
+	});
+
+	it("should throw if the reversal is NOT specified (repro of the bug)", () => {
+		const sourceIdx = 1; // Local
+		const targetIdx = 2; // Merged
+		const sourceLine = 5;
+
+		expect(() => {
+			mapLineAcrossPanes(
+				sourceLine,
+				sourceIdx,
+				targetIdx,
+				diffs,
+				paneCounts,
+				true,
+				[false, false, false, false],
+			);
+		}).toThrow("last chunk outside _sourceMaxLines");
+	});
+
+	it("maps correctly from Local to Merged with disproportionate sizes", () => {
+		const sourceIdx = 1; // Local
+		const targetIdx = 2; // Merged
+		const sourceLine = 5; // 50% through Local
+
+		const result = mapLineAcrossPanes(
+			sourceLine,
+			sourceIdx,
+			targetIdx,
+			diffs,
+			paneCounts,
+			true,
+			[false, true, false, true],
+		);
+
+		expect(result).toBeCloseTo(50, 0);
+	});
+
+	it("handles mapping into a single-line file side gracefully", () => {
+		const emptyDiffs: (DiffChunk[] | null)[] = [
+			null,
+			[{ tag: "delete", start_a: 0, end_a: 10, start_b: 0, end_b: 0 }],
+			null,
+			null,
+		];
+		const counts = [10, 1, 10, 10, 10]; // 1 line minimum for "empty"
+
+		const res = mapLineAcrossPanes(5, 2, 1, emptyDiffs, counts, true, [
+			false,
+			true,
+			false,
+			false,
+		]);
+		expect(res).toBeLessThan(1);
+		expect(res).toBeGreaterThanOrEqual(0);
+	});
+
+	it("handles multiple chunks across panes with mixed reversal states", () => {
+		const complexDiffs: (DiffChunk[] | null)[] = [
+			null,
+			[
+				{ tag: "replace", start_a: 0, end_a: 50, start_b: 0, end_b: 10 },
+				{ tag: "equal", start_a: 50, end_a: 60, start_b: 10, end_b: 20 },
+				{ tag: "replace", start_a: 60, end_a: 100, start_b: 20, end_b: 30 },
+			],
+			[{ tag: "equal", start_a: 0, end_a: 100, start_b: 0, end_b: 100 }],
+			null,
+		];
+		const counts = [100, 30, 100, 100, 100];
+
+		// Complex case: Local(1) to Remote(3) through Merged(2)
+		const res = mapLineAcrossPanes(15, 1, 3, complexDiffs, counts, true, [
+			false,
+			true,
+			false,
+			false,
+		]);
+		expect(res).toBeCloseTo(55, 0);
+	});
+});

--- a/src/webview/ui/scrollMapping.test.ts
+++ b/src/webview/ui/scrollMapping.test.ts
@@ -3,8 +3,8 @@ import type { DiffChunk } from "./types";
 
 describe("mapLineAcrossChunks", () => {
 	it("maps 1:1 when chunks are null or empty", () => {
-		expect(mapLineAcrossChunks(5.5, null, true, 20, 20)).toBe(5.5);
-		expect(mapLineAcrossChunks(3.1, [], false, 20, 20)).toBe(3.1);
+		expect(mapLineAcrossChunks(5.5, null, true, 20, 20, true)).toBe(5.5);
+		expect(mapLineAcrossChunks(3.1, [], false, 20, 20, false)).toBe(3.1);
 	});
 
 	it("clamps to target boundaries when provided", () => {
@@ -61,16 +61,16 @@ describe("mapLineAcrossChunks", () => {
 			// Disabled until AI can explain what it was trying to do or fix its non-smooth implementation
 			//expect(mapLineAcrossChunks(3, chunks, true)).toBe(4);
 			// A: =4 -> 2 lines into A -> 4 lines into B -> B=6
-			expect(mapLineAcrossChunks(4, chunks, true, 10, 15)).toBe(6);
+			expect(mapLineAcrossChunks(4, chunks, true, 10, 15, true)).toBe(6);
 
 			// B to A (Reverse)
 			// B: start=2, b=6 -> 4 lines into B -> 2 lines into A -> A=4
-			expect(mapLineAcrossChunks(6, chunks, false, 15, 10)).toBe(4);
+			expect(mapLineAcrossChunks(6, chunks, false, 15, 10, true)).toBe(4);
 		});
 
 		it("maps correctly before the first asymmetric chunk", () => {
-			expect(mapLineAcrossChunks(1, chunks, true, 10, 15)).toBe(1);
-			expect(mapLineAcrossChunks(1, chunks, false, 15, 10)).toBe(1);
+			expect(mapLineAcrossChunks(1, chunks, true, 10, 15, true)).toBe(1);
+			expect(mapLineAcrossChunks(1, chunks, false, 15, 10, true)).toBe(1);
 		});
 	});
 
@@ -118,14 +118,28 @@ describe("mapLineAcrossChunks", () => {
 			// Verify continuity across the insert: small delta in -> small delta out
 			const EPS = 1e-6;
 			for (let x = 3; x <= 4.9; x += 0.25) {
-				const val = mapLineAcrossChunks(x, chunks, true, 20, 30);
-				const valNext = mapLineAcrossChunks(x + EPS, chunks, true, 20, 30);
+				const val = mapLineAcrossChunks(x, chunks, true, 20, 30, true);
+				const valNext = mapLineAcrossChunks(
+					x + EPS,
+					chunks,
+					true,
+					20,
+					30,
+					true,
+				);
 				expect(Math.abs(valNext - val)).toBeLessThan(1.0);
 			}
 			// And the reverse direction
 			for (let x = 3; x <= 17; x += 0.5) {
-				const val = mapLineAcrossChunks(x, chunks, false, 30, 20);
-				const valNext = mapLineAcrossChunks(x + EPS, chunks, false, 30, 20);
+				const val = mapLineAcrossChunks(x, chunks, false, 30, 20, true);
+				const valNext = mapLineAcrossChunks(
+					x + EPS,
+					chunks,
+					false,
+					30,
+					20,
+					true,
+				);
 				expect(Math.abs(valNext - val)).toBeLessThan(1.0);
 			}
 		});
@@ -138,13 +152,27 @@ describe("mapLineAcrossChunks", () => {
 			// Delete maps a range to a point — already continuous. Verify reverse too.
 			const EPS = 1e-6;
 			for (let x = 4; x <= 18; x += 0.5) {
-				const val = mapLineAcrossChunks(x, chunks, true, 30, 20);
-				const valNext = mapLineAcrossChunks(x + EPS, chunks, true, 30, 20);
+				const val = mapLineAcrossChunks(x, chunks, true, 30, 20, true);
+				const valNext = mapLineAcrossChunks(
+					x + EPS,
+					chunks,
+					true,
+					30,
+					20,
+					true,
+				);
 				expect(Math.abs(valNext - val)).toBeLessThan(1.0);
 			}
 			for (let x = 4; x <= 8; x += 0.25) {
-				const val = mapLineAcrossChunks(x, chunks, false, 20, 30);
-				const valNext = mapLineAcrossChunks(x + EPS, chunks, false, 20, 30);
+				const val = mapLineAcrossChunks(x, chunks, false, 20, 30, true);
+				const valNext = mapLineAcrossChunks(
+					x + EPS,
+					chunks,
+					false,
+					20,
+					30,
+					true,
+				);
 				expect(Math.abs(valNext - val)).toBeLessThan(1.0);
 			}
 		});
@@ -169,9 +197,9 @@ describe("mapLineAcrossChunks", () => {
 				{ tag: "replace", start_a: 5, end_a: 1005, start_b: 5, end_b: 6 },
 			];
 
-			mapLineAcrossChunks(5, chunks, true, 1100, 100);
-			mapLineAcrossChunks(505, chunks, true, 1100, 100);
-			mapLineAcrossChunks(1004, chunks, true, 1100, 100);
+			mapLineAcrossChunks(5, chunks, true, 1100, 100, true);
+			mapLineAcrossChunks(505, chunks, true, 1100, 100, true);
+			mapLineAcrossChunks(1004, chunks, true, 1100, 100, true);
 		});
 	});
 
@@ -211,13 +239,35 @@ describe("mapLineAcrossPanes", () => {
 		const eIn = 1e-8;
 		const eOut = 1e-6;
 		for (let x = 0; x < 20; x++) {
-			const val = mapLineAcrossPanes(Math.max(0, x - eIn), 0, 2, diffs, counts);
-			const valNext = mapLineAcrossPanes(x + eIn, 0, 2, diffs, counts);
+			const val = mapLineAcrossPanes(
+				Math.max(0, x - eIn),
+				0,
+				2,
+				diffs,
+				counts,
+				true,
+				[false, false],
+			);
+			const valNext = mapLineAcrossPanes(x + eIn, 0, 2, diffs, counts, true, [
+				false,
+				false,
+			]);
 			expect(Math.abs(valNext - val)).toBeLessThan(eOut);
 		}
 		for (let x = 0; x < 30; x++) {
-			const val = mapLineAcrossPanes(Math.max(0, x - eIn), 2, 0, diffs, counts);
-			const valNext = mapLineAcrossPanes(x + eIn, 2, 0, diffs, counts);
+			const val = mapLineAcrossPanes(
+				Math.max(0, x - eIn),
+				2,
+				0,
+				diffs,
+				counts,
+				true,
+				[false, false],
+			);
+			const valNext = mapLineAcrossPanes(x + eIn, 2, 0, diffs, counts, true, [
+				false,
+				false,
+			]);
 			expect(Math.abs(valNext - val)).toBeLessThan(eOut);
 		}
 	});
@@ -229,7 +279,10 @@ describe("mapLineAcrossPanes", () => {
 		];
 
 		// Just verify it doesn't throw and produces a finite value
-		const result = mapLineAcrossPanes(5, 0, 2, diffs, [20, 30, 30]);
+		const result = mapLineAcrossPanes(5, 0, 2, diffs, [20, 30, 30], true, [
+			false,
+			false,
+		]);
 		expect(Number.isFinite(result)).toBe(true);
 		expect(result).toBeGreaterThanOrEqual(0);
 	});
@@ -284,6 +337,8 @@ describe("complex multi-pane scenarios", () => {
 					tIdx,
 					complexDiffs,
 					complexCounts,
+					true,
+					[false, false, false, false],
 				);
 				expect(topRes).toBeGreaterThanOrEqual(0);
 
@@ -293,6 +348,8 @@ describe("complex multi-pane scenarios", () => {
 					tIdx,
 					complexDiffs,
 					complexCounts,
+					true,
+					[false, false, false, false],
 				);
 				expect(botRes).toBeLessThanOrEqual(complexCounts[tIdx]);
 			}
@@ -304,13 +361,23 @@ describe("complex multi-pane scenarios", () => {
 		// Verify continuity through it: small input delta -> small output delta
 		const EPS = 1e-6;
 		for (let x = 13; x <= 22; x += 0.5) {
-			const val = mapLineAcrossPanes(x, 0, 1, complexDiffs, complexCounts);
+			const val = mapLineAcrossPanes(
+				x,
+				0,
+				1,
+				complexDiffs,
+				complexCounts,
+				true,
+				[false, false, false, false],
+			);
 			const valNext = mapLineAcrossPanes(
 				x + EPS,
 				0,
 				1,
 				complexDiffs,
 				complexCounts,
+				true,
+				[false, false, false, false],
 			);
 			expect(Math.abs(valNext - val)).toBeLessThan(1.0);
 		}
@@ -321,13 +388,23 @@ describe("complex multi-pane scenarios", () => {
 		// Verify continuity through it: small input delta -> small output delta
 		const EPS = 1e-6;
 		for (let x = 3; x <= 8; x += 0.25) {
-			const val = mapLineAcrossPanes(x, 0, 1, complexDiffs, complexCounts);
+			const val = mapLineAcrossPanes(
+				x,
+				0,
+				1,
+				complexDiffs,
+				complexCounts,
+				true,
+				[false, false, false, false],
+			);
 			const valNext = mapLineAcrossPanes(
 				x + EPS,
 				0,
 				1,
 				complexDiffs,
 				complexCounts,
+				true,
+				[false, false, false, false],
 			);
 			expect(Math.abs(valNext - val)).toBeLessThan(1.0);
 		}
@@ -377,6 +454,8 @@ describe("complex multi-pane scenarios", () => {
 						tIdx,
 						complexDiffs,
 						complexCounts,
+						true,
+						[false, false, false, false],
 					);
 
 					if (bound - EPSILON >= 0) {
@@ -386,6 +465,8 @@ describe("complex multi-pane scenarios", () => {
 							tIdx,
 							complexDiffs,
 							complexCounts,
+							true,
+							[false, false, false, false],
 						);
 						expect(Math.abs(valAtBoundary - valBefore)).toBeLessThan(MAX_DELTA);
 					}
@@ -397,6 +478,8 @@ describe("complex multi-pane scenarios", () => {
 							tIdx,
 							complexDiffs,
 							complexCounts,
+							true,
+							[false, false, false, false],
 						);
 						expect(Math.abs(valAfter - valAtBoundary)).toBeLessThan(MAX_DELTA);
 					}

--- a/src/webview/ui/scrollMapping.ts
+++ b/src/webview/ui/scrollMapping.ts
@@ -235,7 +235,7 @@ export function mapLineAcrossChunks(
 	sourceIsA: boolean,
 	_sourceMaxLines: number,
 	targetMaxLines: number,
-	smooth: boolean = true,
+	smooth: boolean,
 ): number {
 	// Clamp and adapt range [0, _sourceMaxLines]
 	sourceLine = Math.max(0, Math.min(sourceLine, _sourceMaxLines - 1e-10));
@@ -326,6 +326,15 @@ export function mapLineAcrossChunks(
  * @param targetIdx The index of the pane we want to map to
  * @param diffs Array where diffs[i] connects pane i and pane i+1
  * @param paneLineCounts Array of maximum line counts for each pane (used for clamping)
+ * @param smooth Whether to use proportional interpolation instead of discrete jumps
+ * @param diffIsReversed [CRITICAL] Array mapping diff indices to their L/R inversion state.
+ *        By default (false), diffs[i].sideA is pane[i] and diffs[i].sideB is pane[i+1].
+ *        When true, Side A is assumed to be pane[i+1] and Side B is pane[i].
+ *
+ * NOTE: This is required for the 5-way merge view because the payload provides
+ * some diffs (like Local vs Merged) where Side A is the "Merged" pane on the right.
+ * Correct usage for the 5-way view is typically: [false, true, false, true].
+ *
  * @returns The mapped line number on the target pane
  */
 export function mapLineAcrossPanes(
@@ -334,8 +343,12 @@ export function mapLineAcrossPanes(
 	targetIdx: number,
 	diffs: (DiffChunk[] | null)[],
 	paneLineCounts: number[],
-	smooth: boolean = true,
+	smooth: boolean,
+	diffIsReversed: boolean[],
 ): number {
+	if (diffIsReversed.length === 0) {
+		throw new Error("Missing 'diffIsReversed' argument in mapLineAcrossPanes");
+	}
 	if (sourceIdx === targetIdx) {
 		return sourceLine;
 	}
@@ -350,7 +363,8 @@ export function mapLineAcrossPanes(
 	const targetStepIdx = isMovingRight ? sourceIdx + 1 : sourceIdx - 1;
 
 	const chunks = diffs[diffIdx];
-	const sourceIsA = isMovingRight; // Diff[i] connects A:i to B:i+1
+	const isBackwards = diffIsReversed[diffIdx] || false;
+	const sourceIsA = isBackwards ? !isMovingRight : isMovingRight;
 
 	const srcMax = paneLineCounts[sourceIdx];
 	const tgtMax = paneLineCounts[targetStepIdx];
@@ -377,5 +391,6 @@ export function mapLineAcrossPanes(
 		diffs,
 		paneLineCounts,
 		smooth,
+		diffIsReversed,
 	);
 }

--- a/src/webview/ui/useSynchronizedScrolling.ts
+++ b/src/webview/ui/useSynchronizedScrolling.ts
@@ -91,6 +91,7 @@ export const useSynchronizedScrolling = (
 								diffsRef.current,
 								paneCounts,
 								smoothScrolling,
+								[false, true, false, true], // Reversed: diffs[1] (A=2, B=1) and diffs[3] (A=4, B=3)
 							);
 
 							const intTargetLine = Math.floor(targetLineDecimal) + 1;


### PR DESCRIPTION
This is a quick and dirty fix for synced scrolling. An exception gets thrown when one of the code panes is an unexpected length, which happens because of awkward `sourceIsA` booleans passed around that chooses the direction of a diff from A to B instead of B to A, rather than just have an object that implies the direction. The bug happens because the total lines of A and B are defined as source and target instead of A and B 😂. This is in desperate need of a refactor, but for now this is gemini's minimal change solution. I tried suggesting a better refactor but the churn didn't end well. This will do for now. The plan for the future is to first get some better code quality and testing infrastructure happening.