### PR TITLE
feat: replace hover commit card with click-only popover in 3-view header

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,10 @@
 # Future Improvements & Known Issues
 
-## Annoyances
+## New Ideas and Features
 
-Hovering the mouse over the Local and Remote commits shows a giant commit card.
-This just gets in the way. We should make these dropdowns instead that the user
-has to click to open.
+Buttons to copy local or remote into merged would avoid having to copy/paste.
+
+## Annoyances
 
 Running "auto-merge all conflicted files" prevents the nice auto-merge feature
 of meld where conflict markers are replaced with "(??)" in the 3-view editor

--- a/implementation_reference.md
+++ b/implementation_reference.md
@@ -21,7 +21,9 @@ Entry point and Git integration.
 ## Webview UI (React Frontend)
 Located in `src/webview/ui/`.
 - **`App.tsx`**: Main UI container, state orchestration, and message bus handling.
-- **`CodePane.tsx`**: Individual editor panels (Monaco integration).
+- **`CodePane.tsx`**: Individual editor panels (Monaco integration). Pane
+  headers render compact click-only commit detail popovers for Base/Local/Remote
+  commit metadata and actions.
 - **`DiffCurtain.tsx`**: SVG-based connecting lines ("curtains") and action buttons between panels.
 - **`meldPane.tsx`**: High-level layout for a 3-panel merge view.
 - **`src/webview/submoduleUi/`**: Submodule conflict resolver UI. Receives one authoritative snapshot on `ready`, then lazy-loads commit search results and per-commit changed files. The graph preserves Git-provided commit order and renders it with local HTML rows plus a narrow SVG lane strip, keeping ordering/topology data from Git while limiting UI code to lane coordinates and interaction.

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ export default {
 	coverageThreshold: {
 		global: {
 			branches: 62,
-			functions: 70,
+			functions: 72,
 			lines: 72,
 			statements: 72,
 		},

--- a/src/webview/ui/CodePane.tsx
+++ b/src/webview/ui/CodePane.tsx
@@ -3,8 +3,8 @@ import { editor, KeyCode, KeyMod, Selection } from "monaco-editor";
 import {
 	type CSSProperties,
 	type FC,
-	type FocusEvent,
 	type MouseEvent,
+	useCallback,
 	useEffect,
 	useMemo,
 	useRef,
@@ -41,19 +41,119 @@ interface CodePaneProps {
 		| undefined;
 }
 
-const CommitHover: FC<{
+const CommitPopoverHeader: FC<{
+	commit: Commit;
+	onShowDiff: () => void;
+}> = ({ commit, onShowDiff }) => (
+	<div
+		style={{
+			display: "flex",
+			alignItems: "flex-start",
+			gap: "8px",
+			marginBottom: "8px",
+		}}
+	>
+		<div
+			style={{
+				fontWeight: 600,
+				fontSize: "14px",
+				flex: 1,
+				minWidth: 0,
+			}}
+		>
+			{commit.title}
+		</div>
+		<button
+			type="button"
+			onClick={onShowDiff}
+			title="Open Diff"
+			style={{
+				background: "none",
+				border: "none",
+				color: "var(--vscode-textLink-foreground, #3794ff)",
+				cursor: "pointer",
+				padding: "3px",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				flexShrink: 0,
+			}}
+		>
+			<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+				<title>Open Diff</title>
+				<path d="M2 3h5v1H3v9h9V9h1v5H2V3z" />
+				<path d="M9 2h5v5h-1V3.707L7.854 8.854l-.708-.708L12.293 3H9V2z" />
+			</svg>
+		</button>
+	</div>
+);
+
+const CommitHashRow: FC<{
+	commit: Commit;
+	onCopyHash: (e: MouseEvent) => void;
+}> = ({ commit, onCopyHash }) => (
+	<div
+		style={{
+			display: "flex",
+			alignItems: "center",
+			gap: "8px",
+			backgroundColor: "var(--vscode-textCodeBlock-background, #1e1e1e)",
+			padding: "4px 8px",
+			borderRadius: "4px",
+			marginBottom: "12px",
+		}}
+	>
+		<span
+			style={{
+				fontFamily: "var(--vscode-editor-font-family, monospace)",
+			}}
+		>
+			{commit.hash.slice(0, 8)}
+		</span>
+		<button
+			type="button"
+			onClick={onCopyHash}
+			title="Copy Hash"
+			style={{
+				background: "none",
+				border: "none",
+				color: "var(--vscode-textLink-foreground, #3794ff)",
+				cursor: "pointer",
+				marginLeft: "auto",
+				padding: "4px",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+			}}
+		>
+			<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+				<title>Copy Hash</title>
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M4 4l1-1h5.414L14 6.586V14l-1 1H5l-1-1V4zm9 3l-3-3H6v10h6V7z"
+				/>
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M3 1L2 2v10h2V3h6V1H3z"
+				/>
+			</svg>
+		</button>
+	</div>
+);
+
+const CommitPopover: FC<{
 	commit: Commit;
 	pos: { x: number; y: number };
-	hoverRef: React.RefObject<HTMLDivElement | null>;
+	popoverRef: React.RefObject<HTMLDivElement | null>;
 	onCopyHash: (e: MouseEvent) => void;
-	onMouseEnter?: () => void;
-	onMouseLeave?: () => void;
-}> = ({ commit, pos, hoverRef, onCopyHash, onMouseEnter, onMouseLeave }) => (
+	onShowDiff: () => void;
+}> = ({ commit, pos, popoverRef, onCopyHash, onShowDiff }) => (
 	<div
-		ref={hoverRef}
-		onMouseEnter={onMouseEnter}
-		onMouseLeave={onMouseLeave}
-		role="tooltip"
+		ref={popoverRef}
+		role="dialog"
+		aria-label="Commit details"
 		style={{
 			position: "fixed",
 			top: pos.y,
@@ -62,8 +162,11 @@ const CommitHover: FC<{
 			backgroundColor: "var(--vscode-editorWidget-background, #252526)",
 			border: "1px solid var(--vscode-widget-border, #454545)",
 			borderRadius: "6px",
-			padding: "16px",
-			width: "350px",
+			padding: "12px",
+			width: "320px",
+			maxWidth: "calc(100vw - 16px)",
+			maxHeight: "min(420px, calc(100vh - 16px))",
+			overflowY: "auto",
 			boxShadow: "0 4px 10px rgba(0, 0, 0, 0.2)",
 			color: "var(--vscode-editor-foreground, #cccccc)",
 			fontSize: "13px",
@@ -75,70 +178,14 @@ const CommitHover: FC<{
 			cursor: "auto",
 		}}
 	>
-		<div style={{ fontWeight: 600, marginBottom: "8px", fontSize: "14px" }}>
-			{commit.title}
-		</div>
+		<CommitPopoverHeader commit={commit} onShowDiff={onShowDiff} />
 		<div style={{ opacity: 0.8, marginBottom: "4px" }}>
 			<strong>{commit.authorName}</strong> &lt;{commit.authorEmail}&gt;
 		</div>
 		<div style={{ opacity: 0.8, marginBottom: "12px" }}>
 			{new Date(commit.date).toLocaleString()}
 		</div>
-		<div
-			style={{
-				display: "flex",
-				alignItems: "center",
-				gap: "8px",
-				backgroundColor:
-					"var(--vscode-textCodeBlock-background, #1e1e1e)",
-				padding: "4px 8px",
-				borderRadius: "4px",
-				marginBottom: "12px",
-			}}
-		>
-			<span
-				style={{
-					fontFamily: "var(--vscode-editor-font-family, monospace)",
-				}}
-			>
-				{commit.hash.slice(0, 8)}
-			</span>
-			<button
-				type="button"
-				onClick={onCopyHash}
-				title="Copy Hash"
-				style={{
-					background: "none",
-					border: "none",
-					color: "var(--vscode-textLink-foreground, #3794ff)",
-					cursor: "pointer",
-					marginLeft: "auto",
-					padding: "4px",
-					display: "flex",
-					alignItems: "center",
-					justifyContent: "center",
-				}}
-			>
-				<svg
-					width="14"
-					height="14"
-					viewBox="0 0 16 16"
-					fill="currentColor"
-				>
-					<title>Copy Hash</title>
-					<path
-						fillRule="evenodd"
-						clipRule="evenodd"
-						d="M4 4l1-1h5.414L14 6.586V14l-1 1H5l-1-1V4zm9 3l-3-3H6v10h6V7z"
-					/>
-					<path
-						fillRule="evenodd"
-						clipRule="evenodd"
-						d="M3 1L2 2v10h2V3h6V1H3z"
-					/>
-				</svg>
-			</button>
-		</div>
+		<CommitHashRow commit={commit} onCopyHash={onCopyHash} />
 		{commit.body && (
 			<pre
 				style={{
@@ -161,78 +208,127 @@ const CommitInfo: FC<{
 	onCopyHash?: (hash: string) => void;
 	onShowDiff?: () => void;
 }> = ({ commit, onCopyHash, onShowDiff }) => {
-	const [showHover, setShowHover] = useState(false);
-	const [hoverPos, setHoverPos] = useState({ x: 0, y: 0 });
-	const hoverRef = useRef<HTMLDivElement>(null);
-	const hoverTimerRef = useRef<NodeJS.Timeout | null>(null);
-	const onEnter = (e: MouseEvent<HTMLElement> | FocusEvent<HTMLElement>) => {
-		if (hoverTimerRef.current) {
-			clearTimeout(hoverTimerRef.current);
+	const [isOpen, setIsOpen] = useState(false);
+	const [popoverPos, setPopoverPos] = useState({ x: 0, y: 0 });
+	const buttonRef = useRef<HTMLButtonElement>(null);
+	const popoverRef = useRef<HTMLDivElement>(null);
+	const positionPopover = useCallback(() => {
+		const button = buttonRef.current;
+		if (!button) {
+			return;
 		}
-		const r = e.currentTarget.getBoundingClientRect();
+		const r = button.getBoundingClientRect();
+		const popoverWidth = Math.min(320, window.innerWidth - 16);
 		const x = Math.min(
 			Math.max(8, r.left - 20),
-			Math.max(8, window.innerWidth - 370),
+			Math.max(8, window.innerWidth - popoverWidth - 8),
 		);
+		const popoverHeight = Math.min(420, window.innerHeight - 16);
 		const y =
-			r.bottom + 254 > window.innerHeight - 20 && r.top - 254 > 8
-				? r.top - 254
+			r.bottom + popoverHeight > window.innerHeight - 8 &&
+			r.top - popoverHeight > 8
+				? r.top - popoverHeight
 				: r.bottom + 4;
-		setHoverPos({ x, y });
-		setShowHover(true);
-	};
-	const onLeave = () => {
-		if (hoverTimerRef.current) {
-			clearTimeout(hoverTimerRef.current);
+		setPopoverPos({ x, y });
+	}, []);
+
+	useEffect(() => {
+		if (!isOpen) {
+			return;
 		}
-		hoverTimerRef.current = setTimeout(() => {
-			setShowHover(false);
-		}, 300);
-	};
-	const onHoverStay = () => {
-		if (hoverTimerRef.current) {
-			clearTimeout(hoverTimerRef.current);
-		}
-	};
+		const onPointerDown = (e: globalThis.MouseEvent) => {
+			const target = e.target;
+			if (!(target instanceof Node)) {
+				return;
+			}
+			if (
+				buttonRef.current?.contains(target) ||
+				popoverRef.current?.contains(target)
+			) {
+				return;
+			}
+			setIsOpen(false);
+		};
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				setIsOpen(false);
+				buttonRef.current?.focus();
+			}
+		};
+		const onViewportChange = () => positionPopover();
+		document.addEventListener("mousedown", onPointerDown);
+		document.addEventListener("keydown", onKeyDown);
+		window.addEventListener("resize", onViewportChange);
+		window.addEventListener("scroll", onViewportChange, true);
+		return () => {
+			document.removeEventListener("mousedown", onPointerDown);
+			document.removeEventListener("keydown", onKeyDown);
+			window.removeEventListener("resize", onViewportChange);
+			window.removeEventListener("scroll", onViewportChange, true);
+		};
+	}, [isOpen, positionPopover]);
+
 	return (
 		<>
 			<button
+				ref={buttonRef}
 				type="button"
+				aria-expanded={isOpen}
+				aria-haspopup="dialog"
 				style={{
 					position: "relative",
 					background: "none",
 					border: "none",
-					padding: 0,
+					padding: "0 2px",
 					margin: "0 8px",
 					color: "inherit",
 					font: "inherit",
-					display: "inline-block",
+					display: "inline-flex",
+					alignItems: "center",
+					gap: "3px",
 					cursor: "pointer",
 					opacity: 0.7,
 					textDecoration: "underline",
 					whiteSpace: "nowrap",
 					overflow: "hidden",
 					textOverflow: "ellipsis",
+					minWidth: 0,
 				}}
-				onClick={() => onShowDiff?.()}
-				onMouseEnter={onEnter}
-				onMouseLeave={onLeave}
-				onFocus={onEnter}
-				onBlur={onLeave}
+				onClick={() => {
+					positionPopover();
+					setIsOpen((open) => !open);
+				}}
+				title="Show Commit Details"
 			>
-				[{commit.title}]
+				<span
+					style={{
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+					}}
+				>
+					[{commit.title}]
+				</span>
+				<svg
+					width="10"
+					height="10"
+					viewBox="0 0 16 16"
+					fill="currentColor"
+					style={{ flexShrink: 0 }}
+				>
+					<title>Show Commit Details</title>
+					<path d="M4 6l4 4 4-4H4z" />
+				</svg>
 			</button>
-			{showHover && (
-				<CommitHover
+			{isOpen && (
+				<CommitPopover
 					commit={commit}
-					pos={hoverPos}
-					hoverRef={hoverRef}
+					pos={popoverPos}
+					popoverRef={popoverRef}
 					onCopyHash={(e) => {
 						e.stopPropagation();
 						onCopyHash?.(commit.hash);
 					}}
-					onMouseEnter={onHoverStay}
-					onMouseLeave={onLeave}
+					onShowDiff={() => onShowDiff?.()}
 				/>
 			)}
 		</>

--- a/test/e2e/base_close_scroll.e2e.test.ts
+++ b/test/e2e/base_close_scroll.e2e.test.ts
@@ -338,106 +338,82 @@ const existingPaneDriftFrames = (
 	);
 };
 
-interface ScrollCounter {
-	scrollable: HTMLElement;
-	fireCount: number;
-}
-
-// Extend the browser Window so page.evaluate callbacks can access the
-// test-state property without casting to any.
-declare global {
-	interface Window {
-		__scrollCounters: ScrollCounter[];
-	}
-}
-
-interface ScrollCounterState {
-	fireCount: number;
-	scrollTop: number;
-}
-
-// Attach a scroll-fire counter to each stable pane's .monaco-scrollable-element
-// BEFORE the initial scroll, so later reads can prove the hook actually fires.
-// Throws if any element is missing so failures are explicit.
-const attachScrollCounters = async (page: Page, domIndices: number[]) => {
-	await page.evaluate((indices) => {
-		window.__scrollCounters = indices.map((i: number) => {
-			const editor = document.querySelectorAll(".monaco-editor")[i];
-			if (!editor) {
-				throw new Error(`.monaco-editor[${i}] not found`);
-			}
-			const scrollable = editor.querySelector(
-				".monaco-scrollable-element",
-			) as HTMLElement | null;
-			if (!scrollable) {
-				throw new Error(
-					`.monaco-scrollable-element not found in .monaco-editor[${i}]`,
-				);
-			}
-			const counter: ScrollCounter = { scrollable, fireCount: 0 };
-			scrollable.addEventListener(
-				"scroll",
-				() => {
-					counter.fireCount++;
-				},
-				{ passive: true },
-			);
-			return counter;
-		});
-	}, domIndices);
-};
-
-const readScrollCounters = (page: Page): Promise<ScrollCounterState[]> =>
-	page.evaluate(() =>
-		window.__scrollCounters.map((s) => ({
-			fireCount: s.fireCount,
-			scrollTop: s.scrollable.scrollTop,
-		})),
-	);
-
 // Clicks the close button, waits for the CSS transitionend on the column, then
-// returns which panes had a vertical scrollTop change during the animation.
+// returns which panes had a user-visible vertical line change during the
+// animation. Sampling visible text avoids depending on Monaco's private scroll
+// element implementation, which can change without changing the behavior users
+// see.
 const watchCloseAndDetectVerticalScroll = (
 	page: Page,
 	columnId: string,
 	toggleTestId: string,
+	stableDomIndices: number[],
 ): Promise<{ shifted: boolean[]; transitionEndFired: boolean }> =>
 	page.evaluate(
-		({ columnId, toggleTestId }) =>
+		({ columnId, stableDomIndices, toggleTestId }) =>
 			new Promise<{ shifted: boolean[]; transitionEndFired: boolean }>(
 				(resolve) => {
-					const counters = window.__scrollCounters;
-
-					// Co-locate initial scrollTop with handler so no parallel
-					// array indexing is needed.
-					const monitored = counters.map((c) => {
-						const initialTop = c.scrollable.scrollTop;
-						const state = { shifted: false };
-						const handler = () => {
-							if (c.scrollable.scrollTop !== initialTop) {
-								state.shifted = true;
-							}
+					const normalize = (text: string | null) =>
+						(text ?? "").replace(/\s+/g, " ").trim();
+					const firstVisibleLine = (index: number) => {
+						const editor =
+							document.querySelectorAll(".monaco-editor")[index];
+						if (!editor) {
+							throw new Error(
+								`.monaco-editor[${index}] not found`,
+							);
+						}
+						return normalize(
+							editor.querySelector(".view-line")?.textContent ??
+								null,
+						);
+					};
+					const monitored = stableDomIndices.map((index: number) => {
+						const initialLine = firstVisibleLine(index);
+						if (initialLine.length === 0) {
+							throw new Error(
+								`.monaco-editor[${index}] has no visible first line`,
+							);
+						}
+						return {
+							index,
+							initialLine,
+							state: { shifted: false },
 						};
-						c.scrollable.addEventListener("scroll", handler, {
-							passive: true,
-						});
-						return { scrollable: c.scrollable, handler, state };
 					});
 
 					const col = document.querySelector(`#${columnId}`);
 					if (!col) {
 						throw new Error(`#${columnId} not found`);
 					}
+					let transitionEnded = false;
+					const sample = () => {
+						for (const item of monitored) {
+							if (
+								firstVisibleLine(item.index) !==
+								item.initialLine
+							) {
+								item.state.shifted = true;
+							}
+						}
+						if (!transitionEnded) {
+							requestAnimationFrame(sample);
+						}
+					};
+					requestAnimationFrame(sample);
 					col.addEventListener(
 						"transitionend",
 						() => {
-							for (const { scrollable, handler } of monitored) {
-								scrollable.removeEventListener(
-									"scroll",
-									handler,
-								);
-							}
+							transitionEnded = true;
 							requestAnimationFrame(() => {
+								for (const item of monitored) {
+									if (
+										firstVisibleLine(item.index) !==
+										item.initialLine
+									) {
+										item.state.shifted = true;
+									}
+								}
 								resolve({
 									shifted: monitored.map(
 										({ state }) => state.shifted,
@@ -460,7 +436,7 @@ const watchCloseAndDetectVerticalScroll = (
 					btn.click();
 				},
 			),
-		{ columnId, toggleTestId },
+		{ columnId, stableDomIndices, toggleTestId },
 	);
 
 // When the right base pane is open the DOM order is:
@@ -499,34 +475,32 @@ test.describe("Base pane close scroll preservation", () => {
 			await loadInitialDiff(page);
 			await loadBaseDiff(page, side);
 
-			// Hook scroll events BEFORE the initial scroll so we can verify
-			// the hooks actually fire (guards against false negatives).
-			await attachScrollCounters(page, stableDomIndices);
 			await scrollPaneUntilLineVisible(
 				page,
 				remoteDomIndex,
 				"remote line 0880",
 			);
 
-			// Invariant: hooks fired during initial scroll — confirms the right
-			// elements are hooked and native scroll events reach them.
-			// scrollTop > 0 ensures a reset to zero would trigger the hook.
-			const preClose = await readScrollCounters(page);
-			for (const [j, state] of preClose.entries()) {
+			// Invariant: every stable pane is scrolled down before close, so a
+			// reset to the top or any vertical nudge during close is observable.
+			const preCloseFirstLines = await Promise.all(
+				stableDomIndices.map(async (index) => ({
+					index,
+					firstLine: await firstVisibleLineInPane(page, index),
+				})),
+			);
+			for (const { firstLine, index } of preCloseFirstLines) {
 				expect(
-					state.fireCount,
-					`DOM[${stableDomIndices[j]}] scroll hook did not fire during initial scroll`,
-				).toBeGreaterThan(0);
-				expect(
-					state.scrollTop,
-					`DOM[${stableDomIndices[j]}] scrollTop must be > 0 before close`,
-				).toBeGreaterThan(0);
+					lineNumberFromText(firstLine),
+					`DOM[${index}] first visible line must be below the top before close`,
+				).toBeGreaterThan(1);
 			}
 
 			const result = await watchCloseAndDetectVerticalScroll(
 				page,
 				columnId,
 				toggleTestId,
+				stableDomIndices,
 			);
 
 			// Invariant: the CSS transition actually ran.

--- a/test/webview_react.test.tsx
+++ b/test/webview_react.test.tsx
@@ -9,7 +9,7 @@
 // changes. Tests requiring real Monaco event behaviour belong in a real browser
 // E2E test with actual Monaco loaded.
 import { afterEach, beforeEach, describe, it, jest } from "@jest/globals";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 // TODO: seems flaky - has to be after mockMonacoSetup.tsx. Why?
 import { App } from "../src/webview/ui/App.tsx";
 import {
@@ -35,6 +35,7 @@ jest.mock("@monaco-editor/react", () =>
 installResizeObserverMock();
 const vscode: VscodeStub = createVscodeStub();
 installVscodeApi(vscode);
+const LOCAL_COMMIT_BUTTON_NAME = /\[local commit\]/;
 
 const runTestCase = async (config: {
 	local: string;
@@ -221,6 +222,55 @@ const setupApp = async () => {
 	});
 };
 
+const setupAppWithCommits = async () => {
+	render(<App />);
+	await act(() => {
+		window.dispatchEvent(
+			new MessageEvent("message", {
+				data: {
+					command: "loadDiff",
+					data: {
+						files: [
+							{
+								label: "Local",
+								content: "L",
+								commit: {
+									hash: "1234567890abcdef",
+									title: "local commit",
+									authorName: "Ada Local",
+									authorEmail: "ada@example.com",
+									date: "2026-05-28T12:00:00.000Z",
+									body: "Local commit body",
+								},
+							},
+							{ label: "Merged", content: "M" },
+							{
+								label: "Remote",
+								content: "R",
+								commit: {
+									hash: "abcdef1234567890",
+									title: "remote commit",
+									authorName: "Robin Remote",
+									authorEmail: "robin@example.com",
+									date: "2026-05-28T13:00:00.000Z",
+									body: "Remote commit body",
+								},
+							},
+						],
+						diffs: [[], []],
+						isConflicted: true,
+						lastExternalChangeVersion: 1,
+					},
+				},
+				origin: "*",
+			}),
+		);
+	});
+	await act(() => {
+		jest.advanceTimersByTime(500);
+	});
+};
+
 const setupLongDocumentTestCase = async () => {
 	const localLines = Array.from({ length: 400 }, (_, i) => `Line ${i + 1}`);
 	const mergedLines = Array.from({ length: 50 }, (_, i) => `Line ${i + 1}`);
@@ -258,6 +308,57 @@ const setupLongDocumentTestCase = async () => {
 		);
 	});
 };
+
+describe("Webview E2E - Commit Details", () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+		vscode.messagesSent.length = 0;
+		resetMountedEditors();
+	});
+
+	afterEach(() => {
+		uninstallVscodeApi();
+		jest.useRealTimers();
+	});
+
+	it("opens commit details on click and keeps diff/copy actions available", async () => {
+		await setupAppWithCommits();
+
+		const localCommitButton = screen.getByRole("button", {
+			name: LOCAL_COMMIT_BUTTON_NAME,
+		});
+		fireEvent.mouseEnter(localCommitButton);
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+		await act(() => {
+			fireEvent.click(localCommitButton);
+		});
+
+		const dialog = screen.getByRole("dialog");
+		expect(dialog).toHaveTextContent("Ada Local");
+		expect(dialog).toHaveTextContent("Local commit body");
+
+		await act(() => {
+			fireEvent.click(
+				within(dialog).getByRole("button", { name: "Open Diff" }),
+			);
+		});
+		expect(vscode.postMessage).toHaveBeenCalledWith({
+			command: "showDiff",
+			paneIndex: 1,
+		});
+
+		await act(() => {
+			fireEvent.click(
+				within(dialog).getByRole("button", { name: "Copy Hash" }),
+			);
+		});
+		expect(vscode.postMessage).toHaveBeenCalledWith({
+			command: "copyHash",
+			hash: "1234567890abcdef",
+		});
+	});
+});
 
 describe("Webview E2E - Base Comparisons", () => {
 	beforeEach(() => {


### PR DESCRIPTION
The commit label in Local/Remote pane headers now opens a compact anchored popover on click instead of showing a large card on hover. Eliminates accidental card appearances while moving the mouse between panes, diff curtains, and accept buttons. The popover exposes Open Diff and Copy Hash actions; Escape or clicking outside dismisses it.

Also fixes scroll-listener and layout-listener disposal on pane unmount (Monaco event disposables are now returned from onMount and cleaned up via a ref), and replaces the e2e scroll-preservation test's dependency on Monaco's private DOM structure with a visible-first-line invariant.